### PR TITLE
🐛 Fix running in dev mode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@
 import { app, BrowserWindow } from "electron";
 import log from "electron-log";
 import { autoUpdater } from "electron-updater";
-import { createWindow, getPluginName } from "./utils";
+import { createWindow, getPlugin } from "./utils";
 
 const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
@@ -12,7 +12,7 @@ if (!gotTheLock) {
 
 let window: BrowserWindow | null = null;
 try {
-  const { pluginName, pluginPath } = getPluginName();
+  const { pluginPath } = getPlugin();
   if (process.platform === "linux") {
     app.commandLine.appendSwitch("no-sandbox");
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,9 +16,22 @@ function getPluginName(): string {
   }
 }
 
+function getPluginPlatform(): string {
+  switch (process.platform) {
+    case "linux":
+      return "linux";
+    case "darwin":
+      return "mac";
+    case "win32":
+      return "win";
+    default:
+      throw new Error("Impossible de trouver le plugin de votre plateforme.");
+  }
+}
+
 function getPluginPath(pluginName: string): string {
   const pluginPath = electronIsDev
-    ? path.join("plugins", process.platform, process.arch, pluginName)
+    ? path.join("plugins", getPluginPlatform(), process.arch, pluginName)
     : path.join(process.resourcesPath, "plugins", pluginName);
 
   if (!fs.existsSync(pluginPath)) {


### PR DESCRIPTION
I had some difficulty running Blablaland Desktop in dev mode with `npm run start`; the plugin wasn't loading. This PR fixes this issue.

![Blablaland Desktop in dev mode](https://user-images.githubusercontent.com/10495562/145495647-547d78da-d762-4f56-b134-fb8cc7463541.png)

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/10495562/145497814-9c12ddb6-7559-4f40-a1ad-91092dc4d4b9.png">

![image](https://user-images.githubusercontent.com/10495562/145509079-4bfa7181-c1f8-46e6-b435-77440b2f4514.png)


It is using `electronIsDev` to figure out from where to load the plugin.

```typescript
const pluginPath = electronIsDev
  ? path.join("plugins", process.platform, process.arch, pluginName)
  : path.join(process.resourcesPath, "plugins", pluginName);
```

Tested:

* [ ] Windows (Dev)
* [x] Windows (Prod)
* [x] Linux (Dev)
* [x] Linux (Prod)
* [ ] MacOS (Dev)
* [x] MacOS (Prod)